### PR TITLE
Fix: `iframe` element plugin missing `ElementRoot`

### DIFF
--- a/iframe-page-element/admin/src/iframe/IFrameRender.tsx
+++ b/iframe-page-element/admin/src/iframe/IFrameRender.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
 import { css } from "emotion";
+import { ElementRoot } from "@webiny/app-page-builder/render/components/ElementRoot";
 
 const outerWrapper = css({
     boxSizing: "border-box"
@@ -13,7 +14,8 @@ const innerWrapper = css({
     paddingBottom: 0
 });
 
-const IFrameRender = ({ data }) => {
+const IFrameRender = ({ element }) => {
+    const { data } = element;
     // If the user didn't enter a URL, let's show a simple message.
     if (!data.iframe.url) {
         return <div>IFrame URL is missing.</div>;
@@ -21,11 +23,12 @@ const IFrameRender = ({ data }) => {
 
     // Otherwise, let's render the iframe.
     return (
-        <div
+        <ElementRoot
             className={
                 "webiny-pb-base-page-element-style webiny-pb-page-element-embed-iframe " +
                 outerWrapper
             }
+            element={element}
         >
             <div className={innerWrapper}>
                 <div
@@ -33,7 +36,7 @@ const IFrameRender = ({ data }) => {
                 />
                 <iframe src={data.iframe.url} width="100%" height={data.iframe.height} />
             </div>
-        </div>
+        </ElementRoot>
     );
 };
 

--- a/iframe-page-element/admin/src/iframe/iFrameEditor.tsx
+++ b/iframe-page-element/admin/src/iframe/iFrameEditor.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
 import { css } from "emotion";
+import { ElementRoot } from "@webiny/app-page-builder/render/components/ElementRoot";
 
 const outerWrapper = css({
     boxSizing: "border-box"
@@ -21,11 +22,12 @@ const IFrameEditor = props => {
     }
 
     return (
-        <div
+        <ElementRoot
             className={
                 "webiny-pb-base-page-element-style webiny-pb-page-element-embed-iframe " +
                 outerWrapper
             }
+            element={element}
         >
             <div className={innerWrapper}>
                 <div
@@ -33,7 +35,7 @@ const IFrameEditor = props => {
                 />
                 <iframe src={element.data.iframe.url} width="100%" height={element.data.iframe.height} />
             </div>
-        </div>
+        </ElementRoot>
     );
 };
 

--- a/iframe-page-element/admin/src/iframe/index.tsx
+++ b/iframe-page-element/admin/src/iframe/index.tsx
@@ -122,7 +122,7 @@ export default () => {
             type: "pb-render-page-element",
             elementType: "iframe",
             render({ element }) {
-                return <IFrameRender data={element.data} />;
+                return <IFrameRender element={element} />;
             }
         } as PbRenderElementPlugin
     ];

--- a/iframe-page-element/site/src/iframe/iFrameRender.tsx
+++ b/iframe-page-element/site/src/iframe/iFrameRender.tsx
@@ -1,5 +1,7 @@
 import * as React from "react";
 import { css } from "emotion";
+import { ElementRoot } from "@webiny/app-page-builder/render/components/ElementRoot";
+
 const outerWrapper = css({
     boxSizing: "border-box"
 });
@@ -12,7 +14,8 @@ const innerWrapper = css({
     paddingBottom: 0
 });
 
-const IFrame = ({ data }) => {
+const IFrame = ({ element }) => {
+    const { data } = element;
     // If the user didn't enter a URL, let's show a simple message.
     if (!data.iframe.url) {
         return <div>IFrame URL is missing.</div>;
@@ -20,11 +23,12 @@ const IFrame = ({ data }) => {
 
     // Otherwise, let's render the iframe.
     return (
-        <div
+        <ElementRoot
             className={
                 "webiny-pb-base-page-element-style webiny-pb-page-element-embed-iframe " +
                 outerWrapper
             }
+            element={element}
         >
             <div className={innerWrapper}>
                 <div
@@ -32,7 +36,7 @@ const IFrame = ({ data }) => {
                 />
                 <iframe src={data.iframe.url} width="100%" height={data.iframe.height} />
             </div>
-        </div>
+        </ElementRoot>
     );
 };
 

--- a/iframe-page-element/site/src/iframe/index.tsx
+++ b/iframe-page-element/site/src/iframe/index.tsx
@@ -9,7 +9,7 @@ export default () => {
             type: "pb-render-page-element",
             elementType: "iframe",
             render({ element }) {
-                return <IFrameRender data={element.data} />
+                return <IFrameRender element={element} />
             }
         } as PbRenderElementPlugin,
     ];


### PR DESCRIPTION
Every page element should use `ElementRoot` as the root element because it's responsible for adding attributes to the element which are essential for it's working.