### PR TITLE
feat: add customizations for the fullscreen editor

### DIFF
--- a/cms-live-preview/5.42.x/extensions/admin/src/AddPreviewPane.tsx
+++ b/cms-live-preview/5.42.x/extensions/admin/src/AddPreviewPane.tsx
@@ -9,6 +9,7 @@ const { ContentEntry } = ContentEntryEditorConfig;
 
 const SplitView = styled.div`
     display: flex;
+    width: 95vw; // Remove this line in case you are using the legacy entry editor ("cmsLegacyEntryEditor" flag is equal to true).
     > div {
         flex: 1;
     }

--- a/cms-live-preview/5.42.x/extensions/admin/src/PreviewPane.tsx
+++ b/cms-live-preview/5.42.x/extensions/admin/src/PreviewPane.tsx
@@ -7,6 +7,12 @@ const LivePreviewContainer = styled.div`
     display: flex;
     flex-direction: column;
     border-right: 1px solid var(--mdc-theme-on-background);
+
+    // Use a media query to disable the preview pane for screens under 960px wide (or any other preferred width).
+    // You can remove this line in case you are using the legacy entry editor ("cmsLegacyEntryEditor" flag is equal to true).
+    @media screen and (max-width: 960px) {
+        display: none;
+    }
 `;
 
 const Location = styled.div`


### PR DESCRIPTION
## Changes
This PR updates the layout to enhance the responsiveness for smaller screens and accommodates the new fullscreen entry editor introduced in version 5.42.0.

If you are using the legacy entry editor (`cmsLegacyEntryEditor` flag is equal to true), you can easily delete the code marked by the comments in the code.