### PR TITLE
feat: update private model example code

### DIFF
--- a/headless-cms/private-model/5.39.0/books/src/books.app.ts
+++ b/headless-cms/private-model/5.39.0/books/src/books.app.ts
@@ -1,6 +1,6 @@
 import { ContextPlugin } from "@webiny/handler-aws";
 import { Context } from "./types";
-import { CmsModelPlugin } from "@webiny/api-headless-cms";
+import { CmsModelPlugin, isHeadlessCmsReady } from "@webiny/api-headless-cms";
 import WebinyError from "@webiny/error";
 import { booksGraphql } from "./books.graphql";
 import { BOOK_MODEL_ID, createBookModel } from "./book.model";
@@ -9,12 +9,15 @@ import { BooksCrud } from "./books.crud";
 
 export const createBooksApp = () => {
     return new ContextPlugin<Context>(async context => {
+        // Exit early if Headless CMS is not installed.
+        if (!(await isHeadlessCmsReady(context))) {
+            return;
+        }
+
         // Registering the private model.
         context.plugins.register(new CmsModelPlugin(createBookModel()));
 
-        const bookModel = await context.security.withoutAuthorization(() => {
-            return context.cms.getModel(BOOK_MODEL_ID);
-        });
+        const bookModel = context.cms.getModel(BOOK_MODEL_ID);
 
         if (!bookModel) {
             throw new WebinyError(`Missing private model "${BOOK_MODEL_ID}".`);


### PR DESCRIPTION
Minor update to the example code for private models. The update is meant to bring the example code in line with the changes made to the Webiny documentation (at docs.webiny.com).

The wrapper to get the model "unauthorized" has been removed as well. This code was not present in the documentation anymore and furthermore the code that is being called already contains that check. So the check was redundant anyway.

Helped-by: Pavel Denisjuk <pavel@webiny.com>

---

CC: @swapnilmmane 